### PR TITLE
Allow hub-client timeouts to be set through config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,6 @@ A pod for scanning images by combining the powers of the Hub and Perceptor!
 
  - perceptor-scanner pod
    - perceptor-scanner container
+     - downloads a scanclient from the hub upon startup
    - perceptor-imagefacade container
+   

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7b1d55f37005d0412158a1d4108dcf2f6521adb04f07d8e7c1cdce656cb2be4e
-updated: 2018-03-04T12:54:21.732437204-05:00
+hash: cff7cc357fa4de905b1f3e0c56fda09fd1b6f858b164aa2acb02ce3508013ff8
+updated: 2018-03-13T09:05:07.624341143-04:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -12,7 +12,7 @@ imports:
   subpackages:
   - quantile
 - name: github.com/blackducksoftware/hub-client-go
-  version: 39c39f12ffe9cb59b9194ace19f681b1120cc802
+  version: 0a45c9b235d6b5dfe73bcc1e17537eac2b302490
   repo: git@github.com:blackducksoftware/hub-client-go.git
   vcs: git
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,6 +3,7 @@ import:
 - package: github.com/blackducksoftware/hub-client-go
   repo: git@github.com:blackducksoftware/hub-client-go.git
   vcs: git
+  version: v0.9.1
   subpackages:
   - hubapi
   - hubclient

--- a/pkg/scanner/config.go
+++ b/pkg/scanner/config.go
@@ -28,12 +28,13 @@ import (
 )
 
 type Config struct {
-	HubHost         string
-	HubUser         string
-	HubUserPassword string
-	Port            int
-	ImageFacadePort int
-	PerceptorPort   int
+	HubHost                 string
+	HubUser                 string
+	HubUserPassword         string
+	HubClientTimeoutSeconds int
+	Port                    int
+	ImageFacadePort         int
+	PerceptorPort           int
 }
 
 func GetConfig() (*Config, error) {

--- a/pkg/scanner/scanclientdownloader.go
+++ b/pkg/scanner/scanclientdownloader.go
@@ -24,6 +24,7 @@ package scanner
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/blackducksoftware/hub-client-go/hubclient"
 	log "github.com/sirupsen/logrus"
@@ -35,10 +36,10 @@ const (
 
 var scanClientZipPath = fmt.Sprintf("%s/scanclient.zip", scanClientRootPath)
 
-func downloadScanClient(hubHost string, hubUser string, hubPassword string) (*scanClientInfo, error) {
+func downloadScanClient(hubHost string, hubUser string, hubPassword string, timeout time.Duration) (*scanClientInfo, error) {
 	// 1. instantiate hub client
 	hubBaseURL := fmt.Sprintf("https://%s", hubHost)
-	hubClient, err := hubclient.NewWithSession(hubBaseURL, hubclient.HubClientDebugTimings)
+	hubClient, err := hubclient.NewWithSession(hubBaseURL, hubclient.HubClientDebugTimings, timeout)
 	if err != nil {
 		log.Errorf("unable to instantiate hub client: %s", err.Error())
 		return nil, err

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -52,7 +52,11 @@ func NewScanner(config *Config) (*Scanner, error) {
 		return nil, err
 	}
 
-	scanClientInfo, err := downloadScanClient(config.HubHost, config.HubUser, config.HubUserPassword)
+	scanClientInfo, err := downloadScanClient(
+		config.HubHost,
+		config.HubUser,
+		config.HubUserPassword,
+		time.Duration(config.HubClientTimeoutSeconds)*time.Second)
 	if err != nil {
 		log.Errorf("unable to download scan client: %s", err.Error())
 		return nil, err

--- a/vendor/github.com/blackducksoftware/hub-client-go/hubclient/client.go
+++ b/vendor/github.com/blackducksoftware/hub-client-go/hubclient/client.go
@@ -45,7 +45,7 @@ type Client struct {
 	debugFlags    HubClientDebug
 }
 
-func NewWithSession(baseURL string, debugFlags HubClientDebug) (*Client, error) {
+func NewWithSession(baseURL string, debugFlags HubClientDebug, timeout time.Duration) (*Client, error) {
 
 	jar, err := cookiejar.New(nil) // Look more at this function
 
@@ -60,7 +60,7 @@ func NewWithSession(baseURL string, debugFlags HubClientDebug) (*Client, error) 
 	client := &http.Client{
 		Jar:       jar,
 		Transport: tr,
-		Timeout:   5 * time.Second,
+		Timeout:   timeout,
 	}
 
 	return &Client{
@@ -71,7 +71,7 @@ func NewWithSession(baseURL string, debugFlags HubClientDebug) (*Client, error) 
 	}, nil
 }
 
-func NewWithToken(baseURL string, authToken string, debugFlags HubClientDebug) (*Client, error) {
+func NewWithToken(baseURL string, authToken string, debugFlags HubClientDebug, timeout time.Duration) (*Client, error) {
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
@@ -79,7 +79,7 @@ func NewWithToken(baseURL string, authToken string, debugFlags HubClientDebug) (
 
 	client := &http.Client{
 		Transport: tr,
-		Timeout:   5 * time.Second,
+		Timeout:   timeout,
 	}
 
 	return &Client{

--- a/vendor/github.com/blackducksoftware/hub-client-go/hubclient/client_test.go
+++ b/vendor/github.com/blackducksoftware/hub-client-go/hubclient/client_test.go
@@ -17,6 +17,7 @@ package hubclient
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/blackducksoftware/hub-client-go/hubapi"
 	log "github.com/sirupsen/logrus"
@@ -29,7 +30,7 @@ import (
 //   4. that there is at least one project, with a version, with a policy status
 // It's actually an integration test, not a unit test.
 func TestCreateAndDeleteProject(t *testing.T) {
-	client, err := NewWithSession("https://localhost", HubClientDebugTimings)
+	client, err := NewWithSession("https://localhost", HubClientDebugTimings, 5*time.Second)
 	if err != nil {
 		t.Error(err)
 	}

--- a/vendor/github.com/blackducksoftware/hub-client-go/hubclient/currentversion-client_test.go
+++ b/vendor/github.com/blackducksoftware/hub-client-go/hubclient/currentversion-client_test.go
@@ -16,12 +16,13 @@ package hubclient
 
 import (
 	"testing"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
 
 func TestFetchCurrentVersion(t *testing.T) {
-	client, err := NewWithSession("https://localhost", HubClientDebugTimings)
+	client, err := NewWithSession("https://localhost", HubClientDebugTimings, 5*time.Second)
 	client.Login("sysadmin", "blackduck")
 	if err != nil {
 		t.Errorf("unable to instantiate client: %s", err.Error())

--- a/vendor/github.com/blackducksoftware/hub-client-go/hubclient/projects-client_test.go
+++ b/vendor/github.com/blackducksoftware/hub-client-go/hubclient/projects-client_test.go
@@ -17,6 +17,7 @@ package hubclient
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/blackducksoftware/hub-client-go/hubapi"
 )
@@ -28,7 +29,7 @@ import (
 //   4. that there is at least one project, with a version, with a policy status
 // It's actually an integration test, not a unit test.
 func TestFetchPolicyStatus(t *testing.T) {
-	client, err := NewWithSession("https://localhost", HubClientDebugTimings)
+	client, err := NewWithSession("https://localhost", HubClientDebugTimings, 5*time.Second)
 	client.Login("sysadmin", "blackduck")
 	if err != nil {
 		t.Log("unable to instantiate client: " + err.Error())

--- a/vendor/github.com/blackducksoftware/hub-client-go/hubclient/scanclient-client_test.go
+++ b/vendor/github.com/blackducksoftware/hub-client-go/hubclient/scanclient-client_test.go
@@ -16,12 +16,13 @@ package hubclient
 
 import (
 	"testing"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
 
 func TestDownloadScanClient(t *testing.T) {
-	client, err := NewWithSession("https://localhost", HubClientDebugTimings)
+	client, err := NewWithSession("https://localhost", HubClientDebugTimings, 5*time.Second)
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
We need to be able to have a longer timeout when downloading the scan client than when just hitting the hub for ordinary project information.  