### PR TITLE
remove superfluous Dockerfile code

### DIFF
--- a/cmd/perceptor-imagefacade/Dockerfile
+++ b/cmd/perceptor-imagefacade/Dockerfile
@@ -1,6 +1,3 @@
 FROM centos:centos7
 
 COPY ./perceptor-imagefacade ./perceptor-imagefacade
-
-# Run perceptor-scanner
-CMD ["./perceptor-imagefacade"]

--- a/cmd/perceptor-scanner/Dockerfile
+++ b/cmd/perceptor-scanner/Dockerfile
@@ -2,6 +2,3 @@ FROM centos:centos7
 
 # Bring in other dependencies
 COPY ./perceptor-scanner ./perceptor-scanner
-
-# Run perceptor-scanner
-CMD ["./perceptor-scanner"]


### PR DESCRIPTION
These aren't used, now that protoform is responsible for specifying the command.