### PR TITLE
Make Image Facade host configurable

### DIFF
--- a/pkg/scanner/config.go
+++ b/pkg/scanner/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	LogLevel string
 	Port     int
 
+	ImageFacadeHost string
 	ImageFacadePort int
 
 	PerceptorHost string
@@ -52,6 +53,8 @@ func GetConfig(configPath string) (*Config, error) {
 	var config *Config
 
 	viper.SetConfigFile(configPath)
+	// Default ImageFacadeHost to 'localhost'
+	viper.SetDefault("ImageFacadeHost", "localhost")
 
 	err := viper.ReadInConfig()
 	if err != nil {

--- a/pkg/scanner/imagefacadepuller.go
+++ b/pkg/scanner/imagefacadepuller.go
@@ -40,16 +40,16 @@ const (
 )
 
 type ImageFacadePuller struct {
-	ImageFacadeBaseURL string
-	ImageFacadePort    int
-	httpClient         *http.Client
+	ImageFacadeHost string
+	ImageFacadePort int
+	httpClient      *http.Client
 }
 
-func NewImageFacadePuller(imageFacadeBaseURL string, imageFacadePort int) *ImageFacadePuller {
+func NewImageFacadePuller(imageFacadeHost string, imageFacadePort int) *ImageFacadePuller {
 	return &ImageFacadePuller{
-		ImageFacadeBaseURL: imageFacadeBaseURL,
-		ImageFacadePort:    imageFacadePort,
-		httpClient:         &http.Client{Timeout: 5 * time.Second}}
+		ImageFacadeHost: imageFacadeHost,
+		ImageFacadePort: imageFacadePort,
+		httpClient:      &http.Client{Timeout: 5 * time.Second}}
 }
 
 func (ifp *ImageFacadePuller) PullImage(image *common.Image) error {
@@ -88,7 +88,7 @@ func (ifp *ImageFacadePuller) PullImage(image *common.Image) error {
 }
 
 func (ifp *ImageFacadePuller) startImagePull(image *common.Image) error {
-	url := fmt.Sprintf("%s:%d/%s", ifp.ImageFacadeBaseURL, ifp.ImageFacadePort, pullImagePath)
+	url := ifp.buildURL(pullImagePath)
 
 	requestBytes, err := json.Marshal(image)
 	if err != nil {
@@ -117,7 +117,7 @@ func (ifp *ImageFacadePuller) startImagePull(image *common.Image) error {
 }
 
 func (ifp *ImageFacadePuller) checkImage(image *common.Image) (common.ImageStatus, error) {
-	url := fmt.Sprintf("%s:%d/%s?", ifp.ImageFacadeBaseURL, ifp.ImageFacadePort, checkImagePath)
+	url := ifp.buildURL(checkImagePath)
 
 	requestBytes, err := json.Marshal(image)
 	if err != nil {
@@ -156,4 +156,8 @@ func (ifp *ImageFacadePuller) checkImage(image *common.Image) (common.ImageStatu
 	log.Debugf("image check for image %s succeeded", image.PullSpec)
 
 	return getImage.ImageStatus, nil
+}
+
+func (ifp *ImageFacadePuller) buildURL(path string) string {
+	return fmt.Sprintf("http://%s:%d/%s?", ifp.ImageFacadeHost, ifp.ImageFacadePort, path)
 }

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -36,7 +36,6 @@ import (
 
 const (
 	requestScanJobPause = 20 * time.Second
-	imageFacadeBaseURL  = "http://localhost"
 )
 
 type Scanner struct {
@@ -73,7 +72,7 @@ func NewScanner(config *Config) (*Scanner, error) {
 
 	log.Infof("instantiating scanner with hub %s, user %s", config.HubHost, config.HubUser)
 
-	imagePuller := NewImageFacadePuller(imageFacadeBaseURL, config.ImageFacadePort)
+	imagePuller := NewImageFacadePuller(config.ImageFacadeHost, config.ImageFacadePort)
 	scanClient, err := NewHubScanClient(
 		config.HubHost,
 		config.HubUser,


### PR DESCRIPTION
Make the location of the Image Facade service configurable via new
config property ImageFacadeHost. Default to 'localhost' if not
specified.